### PR TITLE
fix isVisible method + fix tooltip position when reach bottom of the map

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -102,7 +102,7 @@ L.Tooltip = L.Class.extend({
 		
 		if (point.x + containerSize.x > mapSize.x) {
 			container.style.left = 'auto';
-			container.style.right = (mapSize.x - point.x) + 'px';
+			container.style.right = (mapSize.x - point.x + 2*(this.options.mouseOffset.x)) + 'px';
 		} else {
 			container.style.left = point.x + 'px';
 			container.style.right = 'auto';
@@ -110,7 +110,7 @@ L.Tooltip = L.Class.extend({
 		
 		if (point.y + containerSize.y > mapSize.y) {
 			container.style.top = 'auto';
-			container.style.bottom = (mapSize.y - point.y) + 'px';
+            container.style.bottom = (mapSize.y - point.y + 2*(this.options.mouseOffset.y)) + 'px';
 		} else {
 			container.style.top = point.y + 'px';
 			container.style.bottom = 'auto';
@@ -174,7 +174,7 @@ L.Tooltip = L.Class.extend({
 		L.DomUtil.removeClass(this._container, 'leaflet-tooltip-fade');
 		this._container.style.display = 'none';
 		
-		this.showing = false;
+		this._showing = false;
 
 		if (L.Tooltip.activeTip === this) {
 			delete L.Tooltip.activeTip;


### PR DESCRIPTION
Hey !

First, thanks for this plugin ;)

Here's a fix for 2 minor problems i encountered with this plugin :
- isVisible() method couldn't work properly since hide() method doesn't modify this._shoing attribute
- When reaching the border of the screen, tooltip's reversed position doesn't deal with mouseOffset and the tooltip can be placed just under the cursor
