### PR TITLE
Fix showDelay option

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -141,7 +141,7 @@ L.Tooltip = L.Class.extend({
 		this.setPosition(point);
 
 		if (this.options.showDelay) {
-			this._delay(this._show, this, this.options.hideDelay);
+			this._delay(this._show, this, this.options.showDelay);
 		} else {
 			this._show();
 		}


### PR DESCRIPTION
Property this.options.hideDelay was used in place of this.options.showDelay in show function
